### PR TITLE
Revive on modern Python: drop madmom/pyrubberband for librosa

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ A powerful audio processing tool that allows you to create new audio from existi
 
 ## Installation
 
+> **Revived for modern Python (2026-06-21).** The old setup required Conda + `madmom` (built from
+> git) + `pyrubberband` — none of which install cleanly on current Python. Those were swapped for
+> `librosa` (beat detection + time-stretch); the granular automixer — the heart of the tool — is
+> unchanged. It now runs headless on plain Python 3.12 with `pip install -r requirements.txt`
+> (system `ffmpeg` required). The Conda instructions below still work but are no longer necessary.
+
+### Quick start (modern, no Conda)
+
+```
+python3 -m venv .venv && . .venv/bin/activate    # or: uv venv .venv
+pip install -r requirements.txt                   # GUI extras optional; system ffmpeg required
+python main.py assets/test_audio.mp3 output/ amc l /2
+```
+
+> Tip: the automixer's pure-Python band-pass + segment-append is O(n²) in track length, so a full
+> 3-minute song is slow. Feed it **short clips** (a handful of seconds) for fast, responsive grain
+> remixes — which is also how the live/ambient capture use-case works.
+
 ### Traditional Method
 
 1. Clone the repository:

--- a/automixer/effects/change_tempo.py
+++ b/automixer/effects/change_tempo.py
@@ -1,24 +1,39 @@
 import numpy as np
 import pydub
-import pyrubberband as pyrb
+
+# Time-stretch (tempo change without pitch shift). Originally pyrubberband, which needs the external
+# `rubberband` CLI binary (not installable without root here). Swapped to librosa.effects.time_stretch
+# — pure Python, no system binary, same semantics (rate > 1 -> faster/shorter). Creative behaviour
+# unchanged; just the engine. — mesh revive 2026-06-21
 
 
 def change_audioseg_tempo(audiosegment, speed, verbose=True):
+    import librosa
+
     if verbose:
         print("Changing playback speed to " + str(speed))
         print("Audio length: " + str(len(audiosegment)))
-    y = np.array(audiosegment.get_array_of_samples())
-    if audiosegment.channels == 2:
-        y = y.reshape((-1, 2))
 
     sample_rate = audiosegment.frame_rate
+    channels = audiosegment.channels
+    # pydub samples are interleaved ints; normalise to float [-1, 1] for librosa.
+    y = np.array(audiosegment.get_array_of_samples()).astype(np.float32) / (2 ** 15)
 
-    y_fast = pyrb.time_stretch(y, sample_rate, speed)
+    if channels == 2:
+        y = y.reshape((-1, 2)).T  # (2, n), librosa stretches per-channel
+        stretched = [
+            librosa.effects.time_stretch(np.ascontiguousarray(y[c]), rate=speed)
+            for c in range(2)
+        ]
+        n = min(len(stretched[0]), len(stretched[1]))
+        out = np.stack([stretched[0][:n], stretched[1][:n]], axis=1).flatten()
+    else:
+        out = librosa.effects.time_stretch(np.ascontiguousarray(y), rate=speed)
 
-    channels = 2 if (y_fast.ndim == 2 and y_fast.shape[1] == 2) else 1
-    y = np.int16(y_fast * 2 ** 15)
-
-    new_seg = pydub.AudioSegment(y.tobytes(), frame_rate=sample_rate, sample_width=2, channels=channels)
+    y_int = np.int16(np.clip(out, -1.0, 1.0) * (2 ** 15))
+    new_seg = pydub.AudioSegment(
+        y_int.tobytes(), frame_rate=sample_rate, sample_width=2, channels=channels
+    )
 
     if verbose:
         print("New audio length: " + str(len(new_seg)))

--- a/cutter/sample_cut_tool.py
+++ b/cutter/sample_cut_tool.py
@@ -3,9 +3,7 @@ import random
 import re
 from datetime import datetime
 
-import madmom
 import traceback
-import matplotlib.pyplot as plt
 import pydub.effects
 import pydub.playback
 import pydub.utils
@@ -86,16 +84,20 @@ class SampleCutter:
         )
 
     def _detect_beats(self):
-        print("Detecting beats...")
+        # Beat detection. Originally madmom (RNNBeatProcessor + DBNBeatTracking), which no longer
+        # installs on modern Python (3.6-era: np.float, collections.MutableSequence, cython-from-git).
+        # Swapped to librosa.beat.beat_track — installs clean, same contract: returns beat positions in
+        # MILLISECONDS (int list), which is all the automixer consumes downstream. The creative core
+        # (rolling-window granular recombination) is untouched. — mesh revive 2026-06-21
+        print("Detecting beats (librosa)...")
         import numpy as np
+        import librosa
 
-        beat_probabilities = madmom.features.beats.RNNBeatProcessor()(
-            self.audio_file_path
-        )
-        beat_positions = madmom.features.beats.DBNBeatTrackingProcessor(fps=100)(
-            beat_probabilities
-        )
-        beat_positions = np.vectorize(lambda x: int(x * 1000))(beat_positions)
+        y, sr = librosa.load(self.audio_file_path, sr=None, mono=True)
+        _tempo, beat_frames = librosa.beat.beat_track(y=y, sr=sr, units="frames")
+        beat_times = librosa.frames_to_time(beat_frames, sr=sr)  # seconds
+        beat_positions = (np.asarray(beat_times) * 1000).astype(int)  # -> ms
+        print(f"Detected {len(beat_positions)} beats")
         return beat_positions
 
     # Define a completer function that returns a list of all previous input
@@ -212,6 +214,7 @@ class SampleCutter:
         print("File loaded from " + audio_file_path)
 
     def plot_amplitude(self, command):
+        import matplotlib.pyplot as plt  # lazy: GUI-only, not needed for headless automix
         selected_samples = self.audio[
             self.current_position : self.current_position + self.sample_length
         ].get_array_of_samples()

--- a/main.py
+++ b/main.py
@@ -1,11 +1,12 @@
 import cutter.sample_cut_tool as sample_cut_tool
 import os
 import sys
-from PySide6.QtWidgets import QApplication
-from main_window import MainWindow
 
 def launch_gui():
     try:
+        # GUI deps (PySide6) imported lazily so headless CLI automix runs without them installed.
+        from PySide6.QtWidgets import QApplication
+        from main_window import MainWindow
         app = QApplication(sys.argv)
         window = MainWindow()
         window.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,22 @@
-cython
-git+https://github.com/CPJKU/madmom.git
-matplotlib
-pydub
-tqdm
-yt-dlp
-PySide6
-pyqtgraph
-pyrubberband
+# Revived for modern Python (tested on 3.12, 2026-06-21).
+# Dropped: madmom + pyrubberband + cython — madmom no longer builds on modern Python (uses np.float,
+# collections.MutableSequence, cython-from-git) and pyrubberband needs the external `rubberband` CLI.
+#   beat detection  -> librosa.beat.beat_track   (cutter/sample_cut_tool.py)
+#   time-stretch     -> librosa.effects.time_stretch (automixer/effects/change_tempo.py)
+# Pure pip, no conda. The CLI automix path needs only the core block below; GUI needs the extras.
+#
+# System prerequisite: ffmpeg (pydub uses it for mp3/m4a/webm I/O).
+
+# --- core (CLI automix) ---
 numpy
 scipy
 librosa
+soundfile
+pydub
+tqdm
+yt-dlp
+
+# --- GUI only (optional: `python main.py` / `--gui`) ---
+matplotlib
+PySide6
+pyqtgraph


### PR DESCRIPTION
This project no longer ran on current Python, so this PR brings it back to life **without touching the granular automixer itself** — the creative heart (beat-windowed random-grain recombination) is byte-for-byte the same. Only the dead upstream engines were swapped.

## Why it was broken
- **`madmom`** (beat detection) is built from a git source that needs an old toolchain (`np.float`, `collections.MutableSequence`, cython-from-git) — it does not install on modern Python (3.10+).
- **`pyrubberband`** (time-stretch) needs the external `rubberband` CLI binary present on the system.
- The **GUI deps** (`PySide6`, `matplotlib`) were imported eagerly at module top, so even the headless CLI could not start without them.

## What changed (engine swaps only)
| Was | Now | Where |
|-----|-----|-------|
| `madmom` RNNBeat + DBNBeatTracking | `librosa.beat.beat_track` | `cutter/sample_cut_tool.py` |
| `pyrubberband.time_stretch` | `librosa.effects.time_stretch` (pure Python, no system binary) | `automixer/effects/change_tempo.py` |
| eager `PySide6` / `matplotlib` imports | lazy (imported only when GUI/plot is used) | `main.py`, `cutter/sample_cut_tool.py` |
| conda + git-build `requirements.txt` | pip-installable set; GUI extras split out & optional | `requirements.txt` |

The beat-detection contract is unchanged (beat positions in **milliseconds**), so the automixer downstream is untouched.

## Verified
Headless on **Python 3.12** (plain venv, `pip install -r requirements.txt`, system `ffmpeg`):

```
python main.py assets/short15.wav output/ amc l /2
# -> Detected 52 beats; produced a valid 75s granular mix (mp3)
```

## Note on speed
Independent of these swaps, the automixer pure-Python band-pass + repeated segment-append is O(n^2) in track length, so a full 3-minute song is slow. Short clips (a handful of seconds) remix fast — documented in the README, and it also fits live/ambient-capture use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)