### PR TITLE
docs: rewrite README so newcomers can tell what the tool does

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,156 +1,138 @@
-# Granular Sampler (grainneukeln)
+# grainneukeln — a granular sampler
 
-A powerful audio processing tool that allows you to create new audio from existing audio using granular synthesis techniques. This tool provides both a command-line interface and a graphical user interface for audio manipulation, beat detection, and sample cutting.
+**In one breath:** give it audio you already have — a song, a field recording, a voice memo — and it
+rebuilds it into *new* audio. It slices the sound into tiny **grains** lined up to the beat, then
+stitches those grains back together in a shuffled, re-filtered order. The result keeps the original's
+pulse and texture but becomes something new — hypnotic, glitchy, remixed. That's **granular
+resynthesis**, driven by the source's own rhythm.
 
-## Features
+Two runs with the same settings give two different tracks (grain picks are random) — but both stay
+locked to the source's groove.
 
-- Audio file loading from local storage or YouTube
-- Beat detection using the madmom library
-- Sample cutting and exporting
-- AutoMixer for creating mixed samples
-- Command-line interface with various commands
-- Graphical user interface using PySide6
-- YouTube audio downloading capability
-- Docker support for easy setup and cross-platform compatibility
+---
 
-## Installation
+## How it works
 
-> **Revived for modern Python (2026-06-21).** The old setup required Conda + `madmom` (built from
-> git) + `pyrubberband` — none of which install cleanly on current Python. Those were swapped for
-> `librosa` (beat detection + time-stretch); the granular automixer — the heart of the tool — is
-> unchanged. It now runs headless on plain Python 3.12 with `pip install -r requirements.txt`
-> (system `ffmpeg` required). The Conda instructions below still work but are no longer necessary.
+What actually happens when you run an automix:
 
-### Quick start (modern, no Conda)
-
-```
-python3 -m venv .venv && . .venv/bin/activate    # or: uv venv .venv
-pip install -r requirements.txt                   # GUI extras optional; system ffmpeg required
-python main.py assets/test_audio.mp3 output/ amc l /2
-```
-
-> Tip: the automixer's pure-Python band-pass + segment-append is O(n²) in track length, so a full
-> 3-minute song is slow. Feed it **short clips** (a handful of seconds) for fast, responsive grain
-> remixes — which is also how the live/ambient capture use-case works.
-
-### Traditional Method
-
-1. Clone the repository:
-   ```
-   git clone https://github.com/yourusername/granular-sampler.git
-   cd granular-sampler
-   ```
-
-2. Create and activate a Conda environment:
-   ```
-   conda create -n grain python=3.9
-   conda activate grain
-   ```
-
-3. Install the required dependencies:
-   ```
-   pip install -r requirements.txt
-   ```
-
-### Docker Method
-
-1. Install Docker on your system (https://docs.docker.com/get-docker/)
-
-2. Clone the repository:
-   ```
-   git clone https://github.com/yourusername/granular-sampler.git
-   cd granular-sampler
-   ```
-
-3. Build and run the Docker container:
-   ```
-   ./run_granular_sampler.sh
-   ```
-
-## Usage
-
-### Command-line Interface
-
-To use the command-line tool, run the `main.py` script with the following syntax:
+1. **Find the beat.** The track is analysed into a list of beat positions (milliseconds). Everything
+   downstream is anchored to these beats — the rhythm of the source becomes the skeleton of the output.
+2. **Slide a window over the beats.** Rather than look at the whole track at once, a *rolling window*
+   moves across the beat list. Its size is `total_beats / window_divider`, so a bigger `w` means a
+   smaller, tighter window — grains get drawn from a narrower slice of time.
+3. **Fill each window with grains.** For every window it builds a chunk:
+   - pick a **random** beat inside the window as the grain's start point,
+   - cut a grain `l` milliseconds long from there,
+   - run it through a **band-pass filter** for each channel (keep only chosen frequency bands),
+   - layer the channels on top of each other,
+   - repeat, appending grains, until the chunk is about one beat long.
+4. **Optionally bend time.** Each grain can be sped up / slowed (`ss`), and the finished mix as a whole
+   can be sped up / slowed (`s`) — pitch-preserving time-stretch.
+5. **Concatenate.** All the window-chunks are joined end to end → your new track (MP3, optionally WAV).
 
 ```
-python main.py <path_to_audio_file_or_youtube_url> <desired_output_path_directory> [automix_parameters]
+source audio
+  │  detect beats  →  ● ● ● ● ● ● ● ● ● ● ● ●      beat positions (ms)
+  │  rolling window   └──[ window ]──┘              size = beats / w
+  │                        ├ pick a RANDOM grain start inside the window
+  │                        ├ cut a grain (length l)
+  │                        ├ band-pass per channel (c)  → layer them
+  │                        └ optional per-grain speed (ss)
+  │  …one chunk per window, each ~one beat long…
+  ▼
+new track  =  chunk₁ + chunk₂ + chunk₃ + …          (+ optional whole-mix speed s)
 ```
 
-#### Basic usage:
-```
-python main.py "/path/to/your/audio.mp3" ~/output/directory/
-```
+---
 
-#### Usage with automix parameters:
-```
-python main.py "/path/to/your/audio.mp3" ~/output/directory/ amc s 0.8 l /2 ss 1.2
-```
+## Install (Python 3.12+, no Conda)
 
-#### Automix Parameters:
-- `s` - Playback speed of the resulting track
-- `ss` - Playback speed of each sample
-- `l` - Length of each sample (use `/` or `*` to divide or multiply the default length)
-- `c` - Channel configuration (e.g., `c 0,200;200,400;400,600`)
-- `w` - Window divider (e.g., `w 3`)
-
-#### Command-line Interface Commands:
-- `p` - Play selected part of the track
-- `b <ms>` - Set beginning of the sample
-- `l <ms>` - Set length of the sample
-- `s <ms>` - Set step for forward and rewind
-- `f` / `r` - Forward / Rewind (use multiple times for faster movement)
-- `plot` - Plot amplitude of the selected part of the track
-- `info` - Print information about cutting the track
-- `load <filepath>` - Change the track to cut
-- `cut` - Cut the track
-- `cut -a` - Cut the track and adjust the cut position
-- `am` - Automix the whole track
-- `amc info` - Show automix configuration
-- `amc m <algorithm> s <playback_speed> l </ or *number>` - Set automix params
-- `set_wav_enabled` / `set_wav_disabled` - Enable/disable WAV export
-- `set_verbose_enabled` / `set_verbose_disabled` - Enable/disable verbose mode
-- `help` - Print help message
-- `q` - Quit
-
-### Graphical User Interface
-
-To use the GUI version of the tool, run:
-
-```
-python main.py
+```bash
+uv venv .venv && . .venv/bin/activate     # or: python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt           # GUI extras are optional
+# system prerequisite: ffmpeg  (pydub uses it for mp3/m4a/webm)
 ```
 
-Or if using Docker:
+Beat detection and time-stretch use **librosa** — no `madmom`/`rubberband` build needed
+(see [PR #3](https://github.com/genaforvena/grainneukeln/pull/3)). The Conda flow still works but
+isn't required.
 
+---
+
+## Use it (command line)
+
+```bash
+python main.py <audio file or YouTube URL> <output dir> [automix params]
 ```
+
+```bash
+# default automix
+python main.py song.mp3 output/
+
+# half-length grains, each grain a touch faster, whole mix a touch slower
+python main.py song.mp3 output/ amc l /2 ss 1.2 s 0.9
+
+# two frequency bands (bass + air), tighter windows
+python main.py song.mp3 output/ amc c 1,250;10000,15000 w 6
+```
+
+### Automix parameters — the `amc` block
+
+| param | meaning | example | what it does |
+|-------|---------|---------|--------------|
+| `l`  | grain length | `l /2`, `l *3`, `l 250` | `/` or `*` scales the beat-derived default; a bare number sets milliseconds. Shorter = finer, more fragmented texture. |
+| `s`  | whole-mix speed | `s 0.8` | tempo of the **final** track (pitch preserved). `<1` slower, `>1` faster. |
+| `ss` | per-grain speed | `ss 1.2` | tempo of **each grain** (pitch preserved) — warps the micro-texture. |
+| `c`  | channels / bands | `c 0,250;250,15000` | one or more `low,high` band-pass bands in Hz, separated by `;`. Each band pulls its **own** random grain and they're layered — e.g. split bass and treble into independent grain streams. |
+| `w`  | window divider | `w 4` | windows = `total_beats / w`. Bigger `w` → smaller windows → grains drawn from tighter time-neighborhoods (more local, less wandering). |
+| `m`  | mode | `m rw` | grain-selection algorithm. `rw` (random window) is the tested default. |
+
+### Interactive shell
+
+Run **without** automix params to drop into an interactive cutter
+(`python main.py song.mp3 output/`):
+
+| command | does |
+|---------|------|
+| `p` | play the current selection |
+| `b <ms>` / `l <ms>` | set selection start / length |
+| `s <ms>` | set the step size for `f`/`r` |
+| `f` / `r` | step forward / rewind (repeat the letter to go further: `fff`) |
+| `cut` / `cut -a` | export the current selection (`-a` snaps to a nearby amplitude peak) |
+| `autocut [n]` | export many cuts automatically |
+| `am` | automix the whole track |
+| `amc …` / `amc info` | set automix params / show the current config |
+| `load <file>` | load a different track |
+| `plot` / `info` | view amplitude / current settings |
+| `set_wav_enabled` / `set_wav_disabled` | also export WAV alongside MP3 |
+| `help` / `q` | help / quit |
+
+---
+
+## GUI
+
+`python main.py` with no arguments launches the PySide6 GUI: load from file or YouTube, detect beats,
+configure and run the automixer, play and save. (GUI extras: `PySide6`, `pyqtgraph`.)
+
+---
+
+## Performance note
+
+The automixer's band-pass + segment-append is pure Python and roughly **O(n²)** in track length, so a
+full 3-minute song takes a while. Feed it **short clips** (a few seconds) for fast, responsive
+remixes — which also fits live/ambient-capture use.
+
+---
+
+## Docker
+
+```bash
 ./run_granular_sampler.sh
 ```
 
-The GUI allows you to:
-1. Load audio files from local storage or YouTube
-2. Detect beats in audio files
-3. Configure and run AutoMixer for granular synthesis
-4. Play original and processed audio
-5. Save processed audio
-
-## Docker Usage
-
-The Docker setup simplifies the installation process and ensures compatibility across different operating systems.
-
-1. Make sure you have Docker installed on your system.
-2. Run the provided shell script:
-   ```
-   ./run_granular_sampler.sh
-   ```
-   This script will build the Docker image and run the container with the appropriate settings for your operating system.
-
-Note: For Windows users, you may need to install an X server like VcXsrv to run GUI applications from Docker.
-
-## Examples
-
-See the `run_with_params.sh` file for examples of running the tool with different parameters.
+Builds the image and runs the container with settings for your OS. Windows users may need an X server
+(e.g. VcXsrv) for the GUI.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions welcome — please open a Pull Request.


### PR DESCRIPTION
Follow-up to #3 (the revive). That PR made the tool *run*; this one makes it *understandable*.

The old README listed features but never explained the **idea** or the **pipeline**, so someone landing on the repo could not tell what actually happens. This is a docs-only rewrite — **no code changes**.

## What is added
- **One-paragraph "what it does"** in plain language: granular resynthesis — slice existing audio into tiny grains aligned to its beat, stitch them back shuffled and re-filtered into a new track that keeps the source groove.
- **"How it works"** — a step-by-step walk through the real pipeline (detect beats → rolling window over beats → pick a random grain per window → band-pass per channel → optional tempo → concatenate), with an ASCII diagram.
- **Plain-language parameter table** for the `amc` block — `l / s / ss / c / w / m` — saying what each one actually changes (not just its name).
- **Interactive-shell command table**.
- Modern install (Python 3.12, librosa, no Conda) up top; performance note kept.

## Why
> "хотелось бы сделать так, чтобы людям было поймать, чё вообще происходит" — make it easy for people to grasp what is going on.

Pure documentation; merges cleanly on top of the merged #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)