### PR TITLE
macro-granular 2/4: polyrhythmic grain streams — Reich-style phasing (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ python main.py song.mp3 output/ amc c 1,250;10000,15000 w 6
 | `ss` | per-grain speed | `ss 1.2` | tempo of **each grain** (pitch preserved) — warps the micro-texture. |
 | `c`  | channels / bands | `c 0,250;250,15000` | one or more `low,high` band-pass bands in Hz, separated by `;`. Each band pulls its **own** random grain and they're layered — e.g. split bass and treble into independent grain streams. |
 | `w`  | window divider | `w 4` | windows = `total_beats / w`. Bigger `w` → smaller windows → grains drawn from tighter time-neighborhoods (more local, less wandering). |
-| `m`  | mode | `m rw`, `m q` | grain-selection algorithm. `rw` (random window) is the tested default; `q` is the **quantized** mixer (below). |
+| `m`  | mode | `m rw`, `m q`, `m poly` | grain-selection algorithm. `rw` (random window) is the tested default; `q` is the **quantized** mixer, `poly` the **polyrhythmic** mixer (both below). |
 | `ek` `en` | euclidean pattern (mode `q`) | `ek 3 en 8` | `E(k, n)`: place `k` grains across `n` beat-subdivision slots as an evenly-spread euclidean rhythm. `E(3,8)` is the tresillo, `E(5,8)` the cinquillo, `E(4,4)` four-on-the-floor. Only used by `m q`. |
+| `pr` | poly streams (mode `poly`) | `pr 4;3`, `pr 4:1-2000;3:6000-15000` | `ratio[@length][:low-high]` stream specs separated by `;`. Each stream fires `ratio` grains per beat; `4;3` is a 3-against-4 polyrhythm. Optional per-stream grain length (ms) and band-pass. Only used by `m poly`. |
 
 #### Quantized mode (`m q`) — designed grooves instead of a uniform fill
 
@@ -145,6 +146,21 @@ the hallucinated grid (no beat floor — same rhythm-seeking regime as `rw`).
 ```bash
 python main.py song.mp3 output/ amc m q ek 3 en 8      # tresillo
 python main.py song.mp3 output/ amc m q ek 5 en 8 ss 1.5   # cinquillo, grains sped up
+```
+
+#### Polyrhythmic mode (`m poly`) — N phasing grain streams (Reich-style)
+
+`rw`/`q` run a **single** stream (one grain at a time). `poly` runs **N parallel streams** at
+different subdivisions of the same beat grid and **overlays** them, so they phase against each other
+(Steve Reich's "Piano Phase", but granular). A stream at `ratio` r fires r grains per beat; two
+streams at 4 and 3 give a **3-against-4** polyrhythm that coincides every `LCM(3,4)=12` subdivisions
+and drifts out of phase in between. Each stream keeps its own grain length and band-pass, so the
+layers stay distinguishable. Beatless input still grinds on the hallucinated grid.
+
+```bash
+python main.py song.mp3 output/ amc m poly pr 4;3                 # 3-against-4, full band
+python main.py song.mp3 output/ amc m poly pr 4:1-2000;3:6000-15000   # split low vs high band
+python main.py song.mp3 output/ amc m poly pr 4@80:1-2000;3@120:6000-15000  # staccato, per-stream length
 ```
 
 ### Interactive shell

--- a/automixer/config.py
+++ b/automixer/config.py
@@ -1,5 +1,6 @@
 from automixer.mixers.default_mixer import RandomWindowAutoMixer
 from automixer.mixers.quantized_mixer import QuantizedAutoMixer
+from automixer.mixers.poly_mixer import PolyphonicAutoMixer
 
 
 class ChannelConfig:
@@ -19,6 +20,7 @@ class AutoMixerConfig:
     modes = {
         "rw": RandomWindowAutoMixer,
         "q": QuantizedAutoMixer,
+        "poly": PolyphonicAutoMixer,
     }
 
     def __init__(self,
@@ -32,7 +34,8 @@ class AutoMixerConfig:
                  window_divider=2,
                  channels_config=[ChannelConfig(0, 15000)],
                  euclid_k=3,
-                 euclid_n=8):
+                 euclid_n=8,
+                 streams=None):
         if mode not in self.modes:
             print("Invalid mode. Defaulting to random.")
             print("Valid modes: " + str(self.modes.keys()))
@@ -51,6 +54,9 @@ class AutoMixerConfig:
         # subdivision slots. Ignored by the rw mixer.
         self.euclid_k = euclid_k
         self.euclid_n = euclid_n
+        # Poly ("poly") mixer: list of {ratio, length?, channels?} stream dicts. None -> a default
+        # 3-against-4. Ignored by the other mixers.
+        self.streams = streams
 
     def __str__(self):
         channel_config = [str(channel) for channel in self.channels_config]

--- a/automixer/iterators/onsets.py
+++ b/automixer/iterators/onsets.py
@@ -1,0 +1,32 @@
+"""Source onset detection, shared by the quantized (#5) and poly (#6) mixers.
+
+Both macro-granular mixers cut grains at the source's transients rather than at arbitrary window
+edges. This is the one onset pass they share: librosa onset detection on the pydub audio, optionally
+snapped to a grid slot so the cut boundaries line up with where the grains are placed.
+"""
+
+
+def onset_positions(audio, snap_ms=0.0):
+    """Onset positions of ``audio`` in ms (sorted, unique).
+
+    ``snap_ms > 0`` snaps each onset to the nearest multiple of ``snap_ms`` (grid quantization of the
+    cut boundaries). Returns ``[]`` when nothing latches — the caller falls back to a random position,
+    never a beat floor (README's rhythm-seeking regime)."""
+    import numpy as np
+    import librosa
+
+    samples = np.array(audio.get_array_of_samples()).astype(np.float32)
+    if audio.channels == 2:
+        samples = samples.reshape((-1, 2)).mean(axis=1)
+    peak = np.max(np.abs(samples)) if samples.size else 0.0
+    if peak > 0:
+        samples = samples / peak
+    sr = audio.frame_rate
+    try:
+        onset_times = librosa.onset.onset_detect(y=samples, sr=sr, units="time")
+    except Exception:
+        return []
+    ms = [t * 1000 for t in onset_times]
+    if snap_ms and snap_ms > 0:
+        return sorted({int(round(round(m / snap_ms) * snap_ms)) for m in ms if m >= 0})
+    return sorted({int(round(m)) for m in ms if m >= 0})

--- a/automixer/mixers/poly_mixer.py
+++ b/automixer/mixers/poly_mixer.py
@@ -1,0 +1,104 @@
+"""Polyphonic macro-granular mixer (issue #6) — mode ``"poly"``.
+
+Where ``rw``/``q`` run a **single** grain stream (one thing at a time, concatenated), this mixer runs
+**N parallel streams** at different subdivisions of the same beat grid and **overlays** them, so they
+phase against each other (Reich "Piano Phase", but granular):
+
+- Each stream has a ``ratio`` r — it fires r grains per beat (``beat_period / r`` apart). Two streams
+  at ratios 3 and 4 give a 3-against-4 polyrhythm that coincides every ``LCM(3,4) = 12`` subdivisions
+  and drifts out of phase in between.
+- Each stream keeps its own grain length and band-pass channels, so the layers stay distinguishable.
+- Grains are cut at source onsets (shared onset pass) and overlaid onto one silent canvas at their
+  grid offsets — a genuine layer, not a concatenation.
+
+No beat floor (README's rhythm-seeking regime): beatless input still grinds on the hallucinated grid;
+< 2 beats falls back to the grain length as the beat period.
+"""
+import random
+from functools import reduce
+from math import gcd
+
+from pydub import AudioSegment
+from tqdm import tqdm
+
+from automixer.effects.band_pass import band_pass_filer
+from automixer.effects.change_tempo import change_audioseg_tempo
+from automixer.iterators.onsets import onset_positions
+from automixer.utils import beat_interval
+
+
+def _lcm(a, b):
+    return a * b // gcd(a, b)
+
+
+class PolyphonicAutoMixer:
+    def mix(self, config, return_streams=False):
+        """Overlay N parallel grain streams. When ``return_streams`` is set, also return the list of
+        per-stream ``AudioSegment``s (each stream rendered on its own canvas) — the honest artifact
+        for verifying each stream's subdivision and their phasing without band-leakage guesswork."""
+        audio = config.audio
+        total_ms = len(audio)
+        if total_ms == 0:
+            return (AudioSegment.empty(), []) if return_streams else AudioSegment.empty()
+
+        streams = getattr(config, "streams", None)
+        if not streams:
+            # Default 3-against-4, both streams full-band.
+            streams = [{"ratio": 4}, {"ratio": 3}]
+
+        beat_period = beat_interval(config.beats)
+        if beat_period <= 0:
+            beat_period = config.sample_length if config.sample_length and config.sample_length > 0 else 500.0
+
+        ratios = [max(1, int(s.get("ratio", 1))) for s in streams]
+        cycle = reduce(_lcm, ratios)  # subdivisions per beat where all streams realign
+        sub_ms = float(beat_period) / cycle
+        # One onset pass at the finest grid the streams share, reused by every stream.
+        onsets = onset_positions(audio, snap_ms=sub_ms)
+
+        total_grains = sum(int(total_ms / (beat_period / r)) + 1 for r in ratios)
+        pbar = tqdm(desc="Polyrhythm", total=total_grains)
+        stream_segs = []
+        for s, ratio in zip(streams, ratios):
+            step_ms = float(beat_period) / ratio            # this stream's subdivision period
+            grain_len = int(round(s.get("length") or step_ms))
+            grain_len = max(1, grain_len)
+            channels = s.get("channels") or config.channels_config
+            seg = AudioSegment.silent(duration=int(round(total_ms)))
+            pos = 0.0
+            while pos < total_ms:
+                grain = self._create_grain(config, onsets, grain_len, channels)
+                if grain is not None and len(grain) > 0:
+                    seg = seg.overlay(grain, position=int(round(pos)))
+                pos += step_ms
+                pbar.update(1)
+            stream_segs.append(seg)
+        pbar.close()
+
+        out = AudioSegment.silent(duration=int(round(total_ms)))
+        for seg in stream_segs:
+            out = out.overlay(seg)
+        return (out, stream_segs) if return_streams else out
+
+    def _create_grain(self, config, onsets, grain_len, channels):
+        """Cut one grain at a random source onset, band-passed through this stream's channels.
+
+        Random onset -> content varies run to run; the stream's grid positions are fixed, so the
+        polyrhythmic PLACEMENT is deterministic."""
+        audio = config.audio
+        max_start = len(audio) - grain_len
+        if max_start <= 0:
+            return audio[:grain_len]
+
+        candidates = [o for o in onsets if 0 <= o <= max_start]
+        start_cut = random.choice(candidates) if candidates else random.randint(0, max_start)
+
+        grain = AudioSegment.silent(duration=grain_len)
+        for channel in channels:
+            channel_chunk = audio[start_cut: start_cut + grain_len]
+            channel_chunk = band_pass_filer(channel.low_pass, channel.high_pass, channel_chunk)
+            grain = grain.overlay(channel_chunk)
+        if config.sample_speed != 1.0:
+            grain = change_audioseg_tempo(grain, config.sample_speed,
+                                          verbose=config.is_verbose_mode_enabled)
+        return grain

--- a/automixer/mixers/quantized_mixer.py
+++ b/automixer/mixers/quantized_mixer.py
@@ -23,6 +23,7 @@ from tqdm import tqdm
 from automixer.effects.band_pass import band_pass_filer
 from automixer.effects.change_tempo import change_audioseg_tempo
 from automixer.iterators.grid import euclidean, grid_slots
+from automixer.iterators.onsets import onset_positions
 from automixer.utils import beat_interval
 
 
@@ -90,26 +91,6 @@ class QuantizedAutoMixer:
         return grain
 
     def _onsets(self, audio, slot_ms):
-        """Source onset positions (ms), snapped to the nearest grid slot.
-
-        Snapping quantizes the cut boundaries to the same grid the grains are placed on, so a grain
-        is a transient *and* metrically aligned. Returns [] when nothing latches (the caller then
-        falls back to a random position — never a beat floor)."""
-        import numpy as np
-        import librosa
-
-        samples = np.array(audio.get_array_of_samples()).astype(np.float32)
-        if audio.channels == 2:
-            samples = samples.reshape((-1, 2)).mean(axis=1)
-        peak = np.max(np.abs(samples)) if samples.size else 0.0
-        if peak > 0:
-            samples = samples / peak
-        sr = audio.frame_rate
-        try:
-            onset_times = librosa.onset.onset_detect(y=samples, sr=sr, units="time")
-        except Exception:
-            return []
-        if slot_ms <= 0:
-            return sorted({int(round(t * 1000)) for t in onset_times})
-        snapped = {int(round(round((t * 1000) / slot_ms) * slot_ms)) for t in onset_times}
-        return sorted(s for s in snapped if s >= 0)
+        """Source onset positions (ms), snapped to the nearest grid slot — see
+        ``automixer.iterators.onsets.onset_positions``."""
+        return onset_positions(audio, snap_ms=slot_ms)

--- a/cutter/sample_cut_tool.py
+++ b/cutter/sample_cut_tool.py
@@ -304,6 +304,27 @@ class SampleCutter:
         if "en" in args:
             euclid_n = int(args[args.index("en") + 1])
 
+        # Poly ("poly") mixer streams: `pr 4:1-2000;3:6000-15000` -> two streams, ratios 4 & 3, each
+        # with its own band; `ratio[@length][:low-high]`, segments separated by ";". Bare `pr 4;3`
+        # runs both streams full-band.
+        streams = self.auto_mixer_config.streams
+        if "pr" in args:
+            spec = args[args.index("pr") + 1]
+            streams = []
+            for seg in spec.split(";"):
+                if not seg:
+                    continue
+                stream = {}
+                head, _, band = seg.partition(":")
+                ratio_part, _, length_part = head.partition("@")
+                stream["ratio"] = int(ratio_part)
+                if length_part:
+                    stream["length"] = float(length_part)
+                if band:
+                    low, high = band.split("-")
+                    stream["channels"] = [ChannelConfig(int(low), int(high))]
+                streams.append(stream)
+
         channels_config = self.auto_mixer_config.channels_config
         if "c" in args:
             channels_config = []
@@ -342,6 +363,7 @@ class SampleCutter:
             channels_config=channels_config,
             euclid_k=euclid_k,
             euclid_n=euclid_n,
+            streams=streams,
         )
 
         print("AutoMixer config: " + str(self.auto_mixer_config))

--- a/tests/test_poly_mixer.py
+++ b/tests/test_poly_mixer.py
@@ -1,0 +1,125 @@
+"""poly mixer (issue #6): N parallel grain streams at different subdivisions, overlaid (Reich phasing).
+
+Zero-dep on purpose — this repo has no test runner. Run it directly:
+
+    PYTHONPATH=. .venv/bin/python tests/test_poly_mixer.py
+
+Verification principle: the artifact, not the assertion. A 3-against-4 config is rendered and the
+mixer hands back each stream as its own rendered ``AudioSegment``; the grain-start timestamps are read
+back out of those segments (detect_nonsilent). The polyrhythm has to be visible in the timestamps:
+stream A (ratio 4) fires every beat/4, stream B (ratio 3) every beat/3, they coincide every 12
+subdivisions (LCM(3,4)), and both are simultaneously non-silent at the crossings in the combined mix
+(genuinely layered, not concatenated).
+
+O(n^2) note (memory grainneukeln-tui-and-venv): the mixer is O(n^2); test sources stay short (<55s).
+"""
+import sys, os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+from pydub import AudioSegment
+from pydub.generators import Sine, WhiteNoise
+from pydub.silence import detect_nonsilent
+
+from automixer.config import AutoMixerConfig, ChannelConfig
+from automixer.mixers.poly_mixer import PolyphonicAutoMixer
+
+failures = []
+
+
+def click_track(period_ms=400, n=6):
+    click = Sine(1000).to_audio_segment(duration=6).apply_gain(-1)
+    rest = AudioSegment.silent(duration=period_ms - 6)
+    track = AudioSegment.silent(duration=0)
+    for _ in range(n):
+        track += click + rest
+    return track
+
+
+def starts_of(seg, min_sil=25):
+    if seg.dBFS == float("-inf"):
+        return []
+    regions = detect_nonsilent(seg, min_silence_len=min_sil, silence_thresh=seg.dBFS - 14, seek_step=1)
+    return [r[0] for r in regions], regions
+
+
+def median_period(starts):
+    s = sorted(starts)
+    if len(s) < 3:
+        return None
+    return float(np.median(np.diff(s)))
+
+
+def near(x, xs, tol):
+    return any(abs(x - y) <= tol for y in xs)
+
+
+# ---- render a 3-against-4 poly mix, keeping the per-stream artifacts -------------------------
+track = click_track(400, 6)  # 2400 ms
+beats = [0, 400, 800, 1200, 1600, 2000]
+streams = [{"ratio": 4}, {"ratio": 3}]
+cfg = AutoMixerConfig(track, beats, sample_length=100, mode="poly", streams=streams)
+combined, segs = PolyphonicAutoMixer().mix(cfg, return_streams=True)
+
+if len(combined) == 0 or len(segs) != 2:
+    failures.append("poly mix did not return a combined mix + 2 stream segments")
+else:
+    beat_period = 400.0
+    sub = beat_period / 12.0  # LCM(3,4)=12 -> 33.3 ms
+
+    (a_starts, a_regions), (b_starts, b_regions) = starts_of(segs[0]), starts_of(segs[1])
+    print("stream A (ratio 4) starts:", a_starts)
+    print("stream B (ratio 3) starts:", b_starts)
+
+    # 1) Each stream fires at its own subdivision: A every beat/4 (=100 ms), B every beat/3 (=133 ms).
+    pa, pb = median_period(a_starts), median_period(b_starts)
+    print("measured period A=%s (expect ~100), B=%s (expect ~133)" % (pa, pb))
+    if pa is None or abs(pa - 100) > 15:
+        failures.append("stream A period %s != ~100 ms (beat/4)" % pa)
+    if pb is None or abs(pb - 133.3) > 18:
+        failures.append("stream B period %s != ~133 ms (beat/3)" % pb)
+
+    # 2) The streams realign every 12 subdivisions (=400 ms): the times where BOTH fire are spaced
+    #    ~400 ms apart — read from the stream onset timestamps, not by ear.
+    coincidences = sorted(t for t in a_starts if near(t, b_starts, sub * 0.6))
+    print("coincidences (both streams fire):", coincidences)
+    cp = median_period(coincidences)
+    print("coincidence period=%s (expect ~400 = 12 subdivisions)" % cp)
+    if cp is None or abs(cp - 400) > 40:
+        failures.append("streams do not realign every 12 subdivisions: coincidence period=%s" % cp)
+
+    # 3) Genuinely LAYERED: there is a time where BOTH streams are non-silent at once (their
+    #    non-silent regions overlap) — concatenation could never produce that. (Energy-summing is
+    #    NOT a valid layering test: two random-phase grains can destructively interfere and lower
+    #    the combined RMS; overlapping non-silent extent is the phase-independent proof.)
+    overlap = any(a0 < b1 and b0 < a1 for a0, a1 in a_regions for b0, b1 in b_regions)
+    if not overlap:
+        failures.append("no time where both streams are non-silent — mix is concatenated, not layered")
+    # The combined mix must actually contain the overlaid material at the crossings.
+    if combined[0:90].dBFS == float("-inf"):
+        failures.append("combined mix is silent at the t=0 crossing where both streams fire")
+
+# ---- 5) Runs on hallucinated-grid hum and with default streams without erroring ---------------
+hum = WhiteNoise().to_audio_segment(duration=1800).apply_gain(-25)
+cfg_hum = AutoMixerConfig(hum, [], sample_length=120, mode="poly", streams=streams)
+try:
+    mix_hum = PolyphonicAutoMixer().mix(cfg_hum)
+    if len(mix_hum) == 0 or mix_hum.dBFS == float("-inf"):
+        failures.append("beatless hum produced an empty/silent poly mix")
+except Exception as e:
+    failures.append("poly mixer errored on beatless hum: %r" % e)
+
+cfg_def = AutoMixerConfig(track, beats, sample_length=100, mode="poly")  # default streams
+try:
+    if len(PolyphonicAutoMixer().mix(cfg_def)) == 0:
+        failures.append("poly mixer with default streams produced an empty mix")
+except Exception as e:
+    failures.append("poly mixer errored with default streams: %r" % e)
+
+if failures:
+    for f in failures:
+        print("FAIL: " + f)
+    sys.exit(1)
+print("ok: 3-against-4 streams fire at beat/4 and beat/3, realign every 12 subdivisions, "
+      "and are genuinely layered (overlapping non-silent streams)")


### PR DESCRIPTION
Closes #6. Builds on #5 (merged).

## What
New mixer mode **`poly`** (`PolyphonicAutoMixer`) — runs **N parallel grain streams** at different subdivisions of the same beat grid and **overlays** them, so they phase against each other (Steve Reich "Piano Phase", but granular). Two streams at ratios 4 and 3 give a **3-against-4** polyrhythm that coincides every `LCM(3,4)=12` subdivisions and drifts out of phase between crossings.

## How
- **`automixer/mixers/poly_mixer.py`** — each stream fires `ratio` grains per beat (`beat_period/ratio` apart), with its own grain length + band-pass channels; grains are overlaid onto one canvas (a genuine layer, not concatenation). `mix(return_streams=True)` also returns each stream as its **own rendered segment** — the honest per-stream artifact for verification. No beat floor.
- **`automixer/iterators/onsets.py`** — onset detection factored out of the quantized mixer and shared by both macro-granular mixers (quantized `_onsets` now delegates; its suite still green).
- **`config.py`** registers `"poly"` + `streams`; **`sample_cut_tool`** adds the `pr` DSL (`ratio[@length][:low-high];...`). `rw`/`q` untouched.

```bash
python main.py song.mp3 output/ amc m poly pr 4;3                       # 3-against-4
python main.py song.mp3 output/ amc m poly pr 4:1-2000;3:6000-15000     # split bands
```

## Verification (the artifact, not the assertion)
Grain-start timestamps are read back out of the **per-stream rendered segments** (`detect_nonsilent`).

- `tests/test_poly_mixer.py` — on a 400 ms click track, stream A (ratio 4) fires every **100 ms** (beat/4), stream B (ratio 3) every **133 ms** (beat/3), coincidences land at **0,400,800,…** → realign every **12 subdivisions**, and the two streams' non-silent regions **overlap** (layered, not concatenated). Stable 8/8 runs.
- Dropped an energy-sum layering check: two random-phase grains can **destructively interfere**, so summed RMS is not a valid layering test — overlapping non-silent extent is the phase-independent proof.
- **Real corpus** (40 s footwork, `yt_kNS58`, staccato grains to expose the grid on continuous audio): rendered stream A period **154 ms = beat/4 exact**, B **205 ms = beat/3 exact**, realign **615 ms = beat_period** from **65 coincidences**, **173** overlapping non-silent region-pairs.

O(n²) cost noted (memory `grainneukeln-tui-and-venv`): test sources kept <55 s. All four suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)